### PR TITLE
fix(openapi): fixed OpenAPI validation error for Directory API yaml file

### DIFF
--- a/directory-api-swagger.yaml
+++ b/directory-api-swagger.yaml
@@ -454,7 +454,6 @@ paths:
   '/v2.1/organisation/{OrganisationId}/certificate':
     parameters:
       - $ref: '#/components/parameters/OrganisationId'
-      - $ref: '#/components/parameters/SoftwareStatementId'
     get:
       summary: Get the certificates for the given organisation
       tags:
@@ -481,7 +480,6 @@ paths:
   '/v2.1/organisation/{OrganisationId}/certificate/{OrganisationCertificateType}':
     parameters:
       - $ref: '#/components/parameters/OrganisationId'
-      - $ref: '#/components/parameters/SoftwareStatementId'
       - $ref: '#/components/parameters/OrganisationCertificateType'
     post:
       summary: Store or create a new certificate of the given OrganisationCertificateType for the given organisation
@@ -489,7 +487,6 @@ paths:
         - Organisation Certificates v2.1
       parameters:
         - $ref: '#/components/parameters/OrganisationId'
-        - $ref: '#/components/parameters/SoftwareStatementId'
         - $ref: '#/components/parameters/OrganisationCertificateType'
       requestBody:
         $ref: '#/components/requestBodies/CertificateOrCSROrJWS'
@@ -1335,7 +1332,6 @@ paths:
   '/v2/organisation/{OrganisationId}/certificate':
     parameters:
       - $ref: '#/components/parameters/OrganisationId'
-      - $ref: '#/components/parameters/SoftwareStatementId'
     get:
       summary: Get the certificates for the given organisation
       tags:
@@ -1362,7 +1358,6 @@ paths:
   '/v2/organisation/{OrganisationId}/certificate/{OrganisationCertificateType}':
     parameters:
       - $ref: '#/components/parameters/OrganisationId'
-      - $ref: '#/components/parameters/SoftwareStatementId'
       - $ref: '#/components/parameters/OrganisationCertificateType'
     post:
       summary: Store or create a new certificate of the given OrganisationCertificateType for the given organisation
@@ -1370,7 +1365,6 @@ paths:
         - Organisation Certificates
       parameters:
         - $ref: '#/components/parameters/OrganisationId'
-        - $ref: '#/components/parameters/SoftwareStatementId'
         - $ref: '#/components/parameters/OrganisationCertificateType'
       requestBody:
         $ref: '#/components/requestBodies/CertificateOrCSROrJWS'
@@ -2218,7 +2212,6 @@ paths:
     parameters:
       - $ref: '#/components/parameters/OrganisationType'
       - $ref: '#/components/parameters/OrganisationId'
-      - $ref: '#/components/parameters/SoftwareStatementId'
     get:
       summary: Get the certificates for the given organisation
       tags:
@@ -2246,7 +2239,6 @@ paths:
     parameters:
       - $ref: '#/components/parameters/OrganisationType'
       - $ref: '#/components/parameters/OrganisationId'
-      - $ref: '#/components/parameters/SoftwareStatementId'
       - $ref: '#/components/parameters/OrganisationCertificateType'
     post:
       summary: Store or create a new certificate of the given OrganisationCertificateType for the given organisation
@@ -2255,7 +2247,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/OrganisationType'
         - $ref: '#/components/parameters/OrganisationId'
-        - $ref: '#/components/parameters/SoftwareStatementId'
         - $ref: '#/components/parameters/OrganisationCertificateType'
       requestBody:
         $ref: '#/components/requestBodies/CertificateOrCSROrJWS'


### PR DESCRIPTION
Postman do not manage to load properly Directory API yaml file cause of an OpenAPI validation error:

```
The parameter 'SoftwareStatementId' is not used in the path `/v2/xxx`
```

Solution: parameter 'SoftwareStatementId' was declared but not used in several paths. I just removed it were not used.