### PR TITLE
AD-9158 remove non-existing params

### DIFF
--- a/scim-swagger.yml
+++ b/scim-swagger.yml
@@ -117,8 +117,6 @@ paths:
       summary: Retrieve the resource
       parameters:
         - $ref: '#/components/parameters/id'
-        - $ref: '#/components/parameters/attributes'
-        - $ref: '#/components/parameters/excludedAttributes'
       responses:
         '200':
           $ref: '#/components/responses/SingleOBAuthorities200'
@@ -237,8 +235,6 @@ paths:
       summary: Retrieve the resource
       parameters:
         - $ref: '#/components/parameters/id'
-        - $ref: '#/components/parameters/attributes'
-        - $ref: '#/components/parameters/excludedAttributes'
       responses:
         '200':
           $ref: '#/components/responses/SingleOBQualifiedTrustServiceProviders200'


### PR DESCRIPTION
Conclusion for missing implementation for attributes/excludedAttributes in case of OBAuthorities and QTSP Resources